### PR TITLE
add tests for extract_coords.py

### DIFF
--- a/tests/test_extract_coords.py
+++ b/tests/test_extract_coords.py
@@ -18,12 +18,6 @@ from neuroconnect.extract_coords import (
     voxel_to_mni,
     extract_tract_coords,
     extract_base_tracts,
-    get_tract_from_df,
-    average_tract_coords,
-    calculate_bcc,
-    calculate_full_cc,
-    calculate_composite_tracts,
-    save_coordinates,
 )
 
 # Tests for find_atlas


### PR DESCRIPTION
closes #20 - unit tests for find_atlas
closes #21 - unit tests for extract start, end and centroid coordinates for one tract
closes #22 - unit tests for looping 48 base tracts